### PR TITLE
Improve JetBrains error highlighting

### DIFF
--- a/jetbrains-plugin/resources/Polar.xml
+++ b/jetbrains-plugin/resources/Polar.xml
@@ -730,10 +730,10 @@
             </option>
             <option name="ERRORS_ATTRIBUTES">
                 <value>
-                    <option name="FOREGROUND" value="3b4252" />
-                    <option name="BACKGROUND" value="bf616a" />
+                    <option name="FOREGROUND" value="bf616a" />
                     <option name="ERROR_STRIPE_COLOR" value="bf616a" />
-                    <option name="EFFECT_TYPE" value="2" />
+                    <option name="EFFECT_TYPE" value="4" />
+                    <option name="EFFECT_COLOR" value="bf616a" />
                 </value>
             </option>
             <option name="EVALUATED_EXPRESSION_ATTRIBUTES">


### PR DESCRIPTION
Change background, foreground and underscore effect of errors to make it more consistent with Nord styling (#10)
<img width="377" alt="image" src="https://user-images.githubusercontent.com/43160711/131124211-7f98b86f-0b64-43bf-91ed-337014840abe.png">
